### PR TITLE
Update variation property to account for multiple alleles

### DIFF
--- a/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
+++ b/models/json/beacon-v2-default-model/genomicVariations/defaultSchema.json
@@ -555,17 +555,18 @@
             "$ref": "#/definitions/VariantLevelData"
         },
         "variation": {
-            "oneOf": [
-                {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/MolecularVariation"
-                },
-                {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation"
-                },
-                {
-                    "$ref": "#/definitions/LegacyVariation"
-                }
-            ]
+            "type": "array",
+            "description": "An array of variations, starting with the reference allele and then the alternate alleles. Alleles can be referenced by their index in the array."
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/MolecularVariation"
+                    },
+                    {
+                        "$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation"
+                    }
+                ]
+            }
         }
     },
     "required": [


### PR DESCRIPTION
Addresses issue #57. In order to capture zygosity (and genotype) in CaseLevelVariants completely, we need to be able to account for the situation where a caseLevelVariant contains two alternate alleles, neither of which is the reference. I would recommend requiring the first element of a variations array, element 0, to be the reference allele, and subsequent alternate alleles to be numbered accordingly. Then zygosity can be represented as in the beacon-ri implementation: 

```
            "caseLevelData": [
              {
                "zygosity": {
                  "label": "0/1",
                  "id": "GENO:GENO_0000458"
                },
                "biosampleId": "HG03770"
              }
            ],
```
with the labeling schema extended in the style of VCF, with values like `1/2`.